### PR TITLE
Update teams.md to include "OpenProject: Hacking Borders"

### DIFF
--- a/teams.md
+++ b/teams.md
@@ -8,3 +8,9 @@ Propose your team here or join an existing team below!
 - **Members**: @janedoe, @johnsmith  
 - **Idea**: Open data platform for public policy transparency.
 
+
+## OpenProject: Hacking Borders
+
+- **Team Lead**: @wielinde (Wieland Lindenthal)
+- **Members**: @dominic-braeunlein (Dominic Bräunlein), @brunopagno (Bruno Pagno), @Kharonus (Eric Schubert), @psatyal (Parimal Satyal), @wielinde (Wieland Lindenthal)
+- **Idea**: From Text Sketch to Project Plan: Integrating Docs with OpenProject (part of openDesk) [#62](https://github.com/johnsmithsuitenumerique/hackdays2025/issues/62)


### PR DESCRIPTION
Hi everyone,

We’re a team of five—maybe six—from OpenProject, and we’re excited to explore how we can integrate the Docs app from La Suite with OpenProject.

Our goal is to break down the current borders between Docs and OpenProject, between La Suite and openDesk, and even between France, the Netherlands, and Germany. We’re not just aiming to connect documents with task management—we want to go deeper.

We'll explore the underlying software layers, like BlockNote, to understand how they can simplify integration efforts and serve as building blocks for a truly Open Source collaboration ecosystem.

Looking forward to hacking and building together!